### PR TITLE
Add cljs.core/MapEntry as a well known type

### DIFF
--- a/src/lib/devtools/defaults.cljs
+++ b/src/lib/devtools/defaults.cljs
@@ -81,6 +81,7 @@
                                                            "cljs.core/PersistentTreeMap"
                                                            "cljs.core/PersistentHashSet"
                                                            "cljs.core/PersistentTreeSet"
+                                                           "cljs.core/MapEntry"
                                                            "cljs.core/Range"
                                                            "cljs.core/ES6IteratorSeq"
                                                            "cljs.core/Eduction"


### PR DESCRIPTION
MapEntry was added in https://dev.clojure.org/jira/browse/CLJS-2013. I'm not really sure why this doesn't show up in the version of CLJS we're running (1.9.671), as https://github.com/clojure/clojurescript/commit/78891af8b68899e0e0456161116aeab23d1c031a seems to have been added as early as 1.9.542.

I wasn't sure what/if/how to test this change, but happy to add it if you point me in the right direction.

Fixes #41.