### PR TITLE
Adjusted styling to work with Firefox

### DIFF
--- a/src/lib/devtools/defaults.clj
+++ b/src/lib/devtools/defaults.clj
@@ -116,12 +116,14 @@
       (sanitize-css (string/join (check-semicolons evald-args))))))
 
 (defmacro get-body-line-common-style []
-  `(css "min-height: 14px;"))
+  `(css "min-height: 14px;"
+        "display: flex;"
+		"align-items: start;"))
 
 (defmacro get-common-type-header-style []
   `(css (str "color: " (named-color :type-text) ";")
         "padding: 0px 2px 0px 2px;"
-        "-webkit-user-select: none;"))
+        "user-select: none;"))
 
 (defmacro get-inner-background-style []
   `(css "position: absolute;"
@@ -152,7 +154,7 @@
   `(css "position: relative;"
         "padding: 0px 4px;"
         "border-radius: 2px;"
-        "-webkit-user-select: none;"))
+        "user-select: none;"))
 
 ; -- style macros -----------------------------------------------------------------------------------------------------------
 
@@ -170,8 +172,9 @@
         "vertical-align: top;"
         "position: relative;"
         "margin-right: 3px;"
+        "margin-top: 2px;"
         "border-radius: 2px;"
-        "-webkit-user-select: none;"
+        "user-select: none;"
         (if (= ~kind :slim)
           "padding: 0px 4px; top:2px;"
           "padding: 1px 4px; top:1px;")))

--- a/src/lib/devtools/defaults.cljs
+++ b/src/lib/devtools/defaults.cljs
@@ -244,7 +244,8 @@
                                                               "padding: 0px 4px 0px 4px;"
                                                               "margin: 1px 0px 0px 0px;")
 
-     :fn-header-style                                    (css)
+     :fn-header-style                                    (css "display: inline-flex;"
+                                                              "align-items: center;")
      :fn-prefix-style                                    (css)
      :nil-style                                          (css (str "color: " (named-color :nil) ";"))
      :keyword-style                                      (css (str "color: " (named-color :keyword) ";"))
@@ -263,14 +264,14 @@
      :native-reference-wrapper-style                     (css "position: relative;"
                                                               "display: inline-flex;")
      :native-reference-style                             (css "padding: 0px 3px;"
-                                                              "margin: -4px 0px -2px;"
                                                               "position: relative;"
                                                               "top: 1px;")
 
      :type-wrapper-style                                 (css "position: relative;"
                                                               "padding-left: 1px;"
                                                               "border-radius: 2px;")
-     :type-ref-style                                     (css "position: relative;")
+     :type-ref-style                                     (css (str "background-color:" (named-color :type) ";")
+                                                              "border-radius: 0 2px 2px 0;")
      :type-header-style                                  (css (d/get-common-type-header-style)
                                                               "border-radius: 2px;")
      :type-name-style                                    (css "padding-right: 4px;")
@@ -323,7 +324,7 @@
                                                               "border-radius: 0 2px 2px 0;")
      :meta-style                                         (css (str "color: " (named-color :meta-text) ";")
                                                               "padding: 0px 3px;"
-                                                              "-webkit-user-select: none;")
+                                                              "user-select: none;")
      :meta-body-style                                    (css (str "background-color: " (named-color :meta 0.1) ";")
                                                               (str "box-shadow: 0px 0px 0px 1px " (named-color :meta) " inset;")
                                                               "position: relative;"
@@ -363,7 +364,7 @@
                                                               "border-radius: 2px;"
                                                               "padding: 0px 4px 0px 4px;"
                                                               "margin: 1px 0px 0px 0px;"
-                                                              "-webkit-user-select: none;")
+                                                              "user-select: none;")
      :body-style                                         (css "display: inline-block;"
                                                               "padding: 3px 12px;"
                                                               (str "border-top: 2px solid " (named-color :body-border) ";")
@@ -380,7 +381,7 @@
                                                               "margin-right: 3px;"
                                                               "padding: 0px 4px 0px 4px;"
                                                               "margin: 1px 0px 0px 0px;"
-                                                              "-webkit-user-select: none;")
+                                                              "user-select: none;")
      :expanded-string-style                              (css "padding: 0px 12px 0px 12px;"
                                                               (str "color: " (named-color :string) ";")
                                                               "white-space: pre;"

--- a/src/lib/devtools/formatters/markup.cljs
+++ b/src/lib/devtools/formatters/markup.cljs
@@ -213,7 +213,7 @@
         (<reference-surrogate> nil preview-markup (or details-markup default-details-fn)))
       preview-markup)))
 
-; -- mete-related markup ----------------------------------------------------------------------------------------------------
+; -- meta-related markup ----------------------------------------------------------------------------------------------------
 
 (defn <meta> [metadata]
   (let [body-fn (fn [] [:meta-body-tag (<preview> metadata)])
@@ -253,9 +253,8 @@
         arities-markup (<arities> arities)
         name-markup (if-not lambda? [:fn-name-tag name])
         icon-markup (if lambda? :lambda-icon :fn-icon)
-        prefix-markup [:fn-prefix-tag icon-markup name-markup]
-        preview-markup [:fn-header-tag prefix-markup arities-markup]
-        details-fn (partial <function-details> fn-obj ns name arities prefix-markup)]
+        preview-markup [:fn-header-tag icon-markup name-markup arities-markup]
+        details-fn (partial <function-details> fn-obj ns name arities icon-markup name-markup)]
     (<reference-surrogate> fn-obj preview-markup details-fn)))
 
 ; -- type markup ------------------------------------------------------------------------------------------------------------
@@ -282,7 +281,6 @@
         preview-markup [(or header-tag :type-header-tag) :type-symbol name-markup]
         details-markup-fn (partial <type-details> constructor-fn ns name basis)]
     [:type-wrapper-tag
-     :type-header-background
      [:type-ref-tag (<reference-surrogate> constructor-fn preview-markup details-markup-fn)]]))
 
 (defn <standalone-type> [constructor-fn & [header-tag]]


### PR DESCRIPTION
With these changes the styles look somewhat the same between the Chrome and the Firefox DevTools.

For Firefox, this change requires the styling changes of https://bugzilla.mozilla.org/show_bug.cgi?id=1818090.

Sebastian